### PR TITLE
Fixed filtering user-defined structs in listening nodes

### DIFF
--- a/StarfireMessenger/Source/StarfireMessengerDeveloper/Private/SGraphPinMessengerType.cpp
+++ b/StarfireMessenger/Source/StarfireMessengerDeveloper/Private/SGraphPinMessengerType.cpp
@@ -99,9 +99,9 @@ public:
 				return false;
 			
 			if (MetaStruct->IsChildOf(FSf_Message_Stateful::StaticStruct( )))
-				return (Found->Type == EMessageType::Immediate);
-			if (MetaStruct->IsChildOf( FSf_Message_Immediate::StaticStruct( ) ))
 				return (Found->Type == EMessageType::Stateful);
+			if (MetaStruct->IsChildOf( FSf_Message_Immediate::StaticStruct( ) ))
+				return (Found->Type == EMessageType::Immediate);
 
 			// Must be a case where we allow anything
 			return true;
@@ -129,9 +129,9 @@ public:
 			return false;
 			
 		if (MetaStruct->IsChildOf(FSf_Message_Stateful::StaticStruct( )))
-			return (Found->Type == EMessageType::Immediate);
-		if (MetaStruct->IsChildOf( FSf_Message_Immediate::StaticStruct( ) ))
 			return (Found->Type == EMessageType::Stateful);
+		if (MetaStruct->IsChildOf( FSf_Message_Immediate::StaticStruct( ) ))
+			return (Found->Type == EMessageType::Immediate);
 
 		// Must be a case where we allow anything
 		return true;


### PR DESCRIPTION
Looks like there is an error when selecting struct in "Listen for Message" and in "Listen for Stateful Message" blueprint nodes. First one is filtering out user-defined structs, registered with type Immediate, and the second one - with type Stateful.

I've tested it in UE 5.6. It looks like this:

Registered structs:
<img width="1280" height="405" alt="image" src="https://github.com/user-attachments/assets/a8121ab3-8f9c-4ae1-ae11-41759dafc0c1" />

Images with mentioned problems:
<img width="650" height="491" alt="image" src="https://github.com/user-attachments/assets/aca2aa9c-6d07-4cef-bab1-8ce199043801" />

<img width="650" height="516" alt="image" src="https://github.com/user-attachments/assets/9aba2fb7-ee92-431c-8966-658426bc0042" />
