### PR TITLE
Adjust for Linux compile

### DIFF
--- a/StarfireMessenger/Source/StarfireMessenger/Public/Messenger/MessageTypes.h
+++ b/StarfireMessenger/Source/StarfireMessenger/Public/Messenger/MessageTypes.h
@@ -72,12 +72,12 @@ public:
 	[[nodiscard]] virtual UClass* GetContextType( ) const { return nullptr; }
 
 	// Utility for finding a message types context type at runtime
-	STARFIREMESSENGER_API [[nodiscard]] static TSoftClassPtr< UObject > GetContextType( const UScriptStruct *MessageType );
+	[[nodiscard]] STARFIREMESSENGER_API  static TSoftClassPtr< UObject > GetContextType( const UScriptStruct *MessageType );
 	// Utility for checking if a message type is stateful at runtime
-	STARFIREMESSENGER_API [[nodiscard]] static bool IsMessageTypeStateful( const UScriptStruct *MessageType );
+	[[nodiscard]] STARFIREMESSENGER_API  static bool IsMessageTypeStateful( const UScriptStruct *MessageType );
 #if WITH_EDITORONLY_DATA
 	// Utility for runtime checking if a type is abstract
-	STARFIREMESSENGER_API [[nodiscard]] static bool IsMessageTypeAbstract( const UScriptStruct *MessageType );
+	[[nodiscard]] STARFIREMESSENGER_API  static bool IsMessageTypeAbstract( const UScriptStruct *MessageType );
 #endif
 };
 SET_MESSAGE_TYPE_AS_ABSTRACT( FSf_MessageBase )

--- a/StarfireMessenger/Source/StarfireMessengerDeveloper/Public/K2Node_StartListeningForMessage.h
+++ b/StarfireMessenger/Source/StarfireMessengerDeveloper/Public/K2Node_StartListeningForMessage.h
@@ -44,7 +44,7 @@ protected:
 	static const FName ListenerHandlePinName;
 
 	// Whether an instanced struct should be output instead of the desired message type
-	UPROPERTY( EditDefaultsOnly )
+	UPROPERTY( EditDefaultsOnly, Category="Starfire Messenger" )
 	bool bListenHierarchically = false;
 	
 	// copied from Epic's ConstructObjectFromClass node


### PR DESCRIPTION
As I discovered after moving to Fedora from Windows 11, the compiler does not like nodiscard ahead of STARFIREMESSENGER_API.  Additionally add a category to K2Node_StartListeningForMessage, addressing a Engine level compile error

Discussed this in the Unreal Source Discord as well, just bringing it here.